### PR TITLE
Add a way to see all devices on smaller Xcode screens

### DIFF
--- a/Trait-Based View.xctemplate/___FILEBASENAME___.playground/Sources/PlaygroundController.swift
+++ b/Trait-Based View.xctemplate/___FILEBASENAME___.playground/Sources/PlaygroundController.swift
@@ -25,20 +25,34 @@ public func playgroundController(
   traits: UITraitCollection = .init())
   -> UIViewController
 {
+  let scale = PlaygroundController.scale
+  let playgroundSize = CGSize(width: size.width * scale, height: size.height * scale)
+    
   let parent = UIViewController()
-  parent.view.frame.size = size
-  parent.preferredContentSize = parent.view.frame.size
+  parent.view.frame.size = playgroundSize
+  parent.preferredContentSize = playgroundSize
   parent.view.addSubview(viewController.view)
   parent.addChild(viewController)
 
-  viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-  viewController.view.frame = parent.view.frame
+  viewController.view.transform = CGAffineTransform(scaleX: scale, y: scale)
+
+  viewController.view.translatesAutoresizingMaskIntoConstraints = false
+  NSLayoutConstraint.activate([
+    NSLayoutConstraint(item: viewController.view, attribute: .centerX, relatedBy: .equal, toItem: parent.view, attribute: .centerX, multiplier: 1, constant: 0),
+    NSLayoutConstraint(item: viewController.view, attribute: .centerY, relatedBy: .equal, toItem: parent.view, attribute: .centerY, multiplier: 1, constant: 0),
+    NSLayoutConstraint(item: viewController.view, attribute: .width, relatedBy: .equal, toItem: parent.view, attribute: .width, multiplier: 1/scale, constant: 0),
+    NSLayoutConstraint(item: viewController.view, attribute: .height, relatedBy: .equal, toItem: parent.view, attribute: .height, multiplier: 1/scale, constant: 0)
+  ])
 
   parent.view.backgroundColor = .white
 
   parent.setOverrideTraitCollection(traits, forChild: viewController)
 
   return parent
+}
+
+public struct PlaygroundController {
+    public static var scale: CGFloat = 1.0
 }
 
 public enum Orientation {


### PR DESCRIPTION
It seems like there's no way to scale down the Playground's live view? At least while also "tricking" the contained view controller to think it's the "right" size in points. So this is an idea of how to do that. Demo is here: https://github.com/quantcon/Swift The screenshots are from a 13" screen with the OS scaling turned up all the way. **The resulting math isn't 100% correct since it should be 1024x1366.